### PR TITLE
[fix/jwt] jwt subject 값 -> claim 재변경

### DIFF
--- a/src/main/java/com/jupjup/www/jupjup/config/JWTUtil.java
+++ b/src/main/java/com/jupjup/www/jupjup/config/JWTUtil.java
@@ -59,11 +59,11 @@ public class JWTUtil {
         Date refreshDate = new Date(System.currentTimeMillis() + refreshExpirationTime);
 
         return Jwts.builder()
-                .subject(String.valueOf(userId))
-                .subject(userName)
-                .subject(userEmail)
+                .claim("userId", String.valueOf(userId))
+                .claim("userName", userName)
+                .claim("userEmail", userEmail)
                 // 액세스 토큰 발급 시 리프레시 만료시간 같이 보내 DB접근 줄이기
-                .subject(String.valueOf(refreshDate))
+                .claim("refreshTokenExpiration", new Date(System.currentTimeMillis() + refreshExpirationTime))
                 .issuedAt(new Date(System.currentTimeMillis()))  // 토큰 발급 시간
                 .expiration(new Date(System.currentTimeMillis() + expirationTime)) // 만료 시
                 .signWith(key)
@@ -136,7 +136,7 @@ public class JWTUtil {
     }
 
     public static Long getUserIdFromRefreshToken(String token) {
-        return Long.valueOf(extractClaim(token, refreshEncKey, "userName"));
+        return Long.valueOf(extractClaim(token, refreshEncKey, "userId"));
     }
 
     public static String getUserNameFromRefreshToken(String token) {

--- a/src/main/java/com/jupjup/www/jupjup/service/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/jupjup/www/jupjup/service/oauth/CustomOAuth2UserService.java
@@ -56,7 +56,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
      * 각 리소스 제공자(네이버, 구글, 카카오)에 따라 사용자의 속성을 파싱하여 특정 형식의 응답을 반환
      * 지원되지 않는 등록 ID가 입력되면 IllegalArgumentException 발생
      *
-     * @param oAuth2User OAuth2 인증을 통해 얻은 사용자 정보
+     * @param oAuth2User     OAuth2 인증을 통해 얻은 사용자 정보
      * @param registrationId 리소스 제공자를 식별하는 ID (예: 네이버, 구글, 카카오)
      * @return OAuth2Response 각 리소스 제공자에 맞게 변환된 사용자 정보를 담은 응답 객체
      * @throws IllegalArgumentException 지원되지 않는 리소스 제공자 ID가 입력될 경우 예외 발생
@@ -69,19 +69,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         } else if (registrationId == GOOGLE) {
             log.info("구글 로그인");
             return new GoogleResponse(oAuth2User.getAttributes());
-        } else if(registrationId == KAKAO){
+        } else if (registrationId == KAKAO) {
             log.info("카카오 로그인");
             return new KakaoResponse(oAuth2User.getAttributes());
-        }else{
+        } else {
             throw new IllegalArgumentException("지원되지 않는 리소스 제공자 입니다. registration id: " + registrationId);
         }
     }
 
     /**
-     * @author        : boramkim
-     * @since         : 2024. 8. 1.
-     * @description   : 가입이 안된 유저이면 회원가입되고 가입되어 있다면 기존계정 내용 업데이트
-     *                   카카오의 경우 이메일을 내려보내주지 않아, 닉네임+key 로 email insert
+     * @author : boramkim
+     * @description : 가입이 안된 유저이면 회원가입되고 가입되어 있다면 기존계정 내용 업데이트
+     * 카카오의 경우 이메일을 내려보내주지 않아, 닉네임+key 로 email insert
+     * @since : 2024. 8. 1.
      */
     private OAuth2User saveOrUpdateUser(OAuth2Response oAuth2Response) {
         String providerId = oAuth2Response.getProvider() + oAuth2Response.getProviderId();
@@ -95,7 +95,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return registerNewUser(providerId, userName, userEmail);
         } else {
             log.info("기가입 유저 => 정보 업데이트");
-            return updateExistingUser(existingUser, userName, userEmail,providerId);
+            return updateExistingUser(existingUser, userName, userEmail, providerId);
         }
     }
 
@@ -122,11 +122,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .build());
     }
 
-    private OAuth2User updateExistingUser(User user, String userName, String userEmail,String providerId) {
+    private OAuth2User updateExistingUser(User user, String userName, String userEmail, String providerId) {
         user.setUserEmail(userEmail);
         user.setName(userName);
         userRepository.save(user);
         return new CustomUserDetails(UserResponse.builder()
+                .userId(user.getId())
                 .providerId(providerId)
                 .username(userName)
                 .userEmail(userEmail)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- subject 는 jwt 기본 필드이므로 하나의 값만 저장할 수 있습니다.
- 그리고 JWTUtil 의 `getUser*From*Token` 메서드들도 클레임에서 값을 추출하고 있어 저장하는 값들의 필드를 클레임으로 변경합니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 중점적으로 확인 할 요청 사항

